### PR TITLE
fix(MatchChat): pass allyTeamID into getIdColor for team colors

### DIFF
--- a/gex/src/view/match/components/MatchChat.vue
+++ b/gex/src/view/match/components/MatchChat.vue
@@ -114,7 +114,7 @@
                         id: index,
                         from: this.getIdName(iter.fromId),
                         to: this.getIdName(iter.toId, allyTeamID),
-                        color: this.getIdColor(iter.toId),
+                        color: this.getIdColor(iter.toId, allyTeamID),
                         playerColor: this.getPlayerColor(iter.fromId),
                         timestamp: TimeUtils.duration(iter.gameTimestamp),
                         message: iter.message


### PR DESCRIPTION
likely a bad merge missed this line

![image](https://github.com/user-attachments/assets/b67d7d54-0aa1-4ca0-bace-37130dfcdbb4)
