### PR TITLE
Current metal and energy

### DIFF
--- a/gex/Models/Event/GameEventExtraStatUpdate.cs
+++ b/gex/Models/Event/GameEventExtraStatUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using Dapper.ColumnMapper;
 using gex.Code;
+using System.Text.Json.Serialization;
 
 namespace gex.Models.Event {
 
@@ -10,9 +11,9 @@ namespace gex.Models.Event {
         [ColumnMapping("team_id")]
         public int TeamID { get; set; }
 
-        [JsonActionLogPropertyName("totalValue")]
-        [ColumnMapping("total_value")]
-        public double TotalValue { get; set; }
+		[JsonActionLogPropertyName("totalValue")]
+		[ColumnMapping("total_value")]
+		public double TotalValue { get; set; }
 
         [JsonActionLogPropertyName("armyValue")]
         [ColumnMapping("army_value")]
@@ -20,19 +21,19 @@ namespace gex.Models.Event {
 
         [JsonActionLogPropertyName("defValue")]
         [ColumnMapping("defense_value")]
-        public double DefenseValue { get; set; }
+		public double DefenseValue { get; set; }
 
         [JsonActionLogPropertyName("utilValue")]
         [ColumnMapping("util_value")]
-        public double UtilValue { get; set; }
+		public double UtilValue { get; set; }
 
         [JsonActionLogPropertyName("ecoValue")]
         [ColumnMapping("eco_value")]
-        public double EcoValue { get; set; }
+		public double EcoValue { get; set; }
 
         [JsonActionLogPropertyName("otherValue")]
         [ColumnMapping("other_value")]
-        public double OtherValue { get; set; }
+		public double OtherValue { get; set; }
 
         [JsonActionLogPropertyName("buildPowerAvailable")]
         [ColumnMapping("build_power_available")]
@@ -41,6 +42,14 @@ namespace gex.Models.Event {
         [JsonActionLogPropertyName("buildPowerUsed")]
         [ColumnMapping("build_power_used")]
         public double BuildPowerUsed { get; set; }
+
+        [JsonActionLogPropertyName("metalCurrent")]
+        [ColumnMapping("metal_current")]
+        public double MetalCurrent { get; set; }
+
+        [JsonActionLogPropertyName("energyCurrent")]
+        [ColumnMapping("energy_current")]
+        public double EnergyCurrent { get; set; }
 
     }
 }

--- a/gex/README.md
+++ b/gex/README.md
@@ -28,6 +28,12 @@ Gex is a c# webserver that fetches public Beyond All Reason games, downloads the
 1. `npm run build`
 1. `dotnet run`
 1. view at https://localhost:6001/
+2. Create and permissions /replays folder
+dotnet user-secrets set Discord:GuildId $VALUE
+
+Create all the folders referenced and erroring out, like 
+/temp/test_write.txt
+
 
 NOTE: type `.close` into the console window to properly close the game. This will kill any BAR games running as well, and properly cancel everything
 

--- a/gex/Services/Db/Event/GameEventExtraStatsDb.cs
+++ b/gex/Services/Db/Event/GameEventExtraStatsDb.cs
@@ -1,7 +1,11 @@
-﻿using gex.Code.ExtensionMethods;
+﻿using Dapper;
+using gex.Code.ExtensionMethods;
 using gex.Models.Event;
 using Microsoft.Extensions.Logging;
 using Npgsql;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace gex.Services.Db.Event {
 
@@ -15,11 +19,11 @@ namespace gex.Services.Db.Event {
                 INSERT INTO game_event_extra_stats (
                     game_id, frame, team_id,
                     total_value, army_value, defense_value, util_value, eco_value, other_value,
-                    build_power_available, build_power_used
+                    build_power_available, build_power_used, metal_current, energy_current
                 ) VALUES (
                     @GameID, @Frame, @TeamID,
                     @TotalValue, @ArmyValue, @DefenseValue, @UtilValue, @EcoValue, @OtherValue,
-                    @BuildPowerAvailable, @BuildPowerUsed
+                    @BuildPowerAvailable, @BuildPowerUsed, @MetalCurrent, @EnergyCurrent
                 );
             ";
 
@@ -33,6 +37,8 @@ namespace gex.Services.Db.Event {
             cmd.AddParameter("UtilValue", ev.UtilValue);
             cmd.AddParameter("EcoValue", ev.EcoValue);
             cmd.AddParameter("OtherValue", ev.OtherValue);
+            cmd.AddParameter("MetalCurrent", ev.MetalCurrent);
+            cmd.AddParameter("EnergyCurrent", ev.EnergyCurrent);
 
             cmd.AddParameter("BuildPowerAvailable", ev.BuildPowerAvailable);
             cmd.AddParameter("BuildPowerUsed", ev.BuildPowerUsed);

--- a/gex/gex.lua
+++ b/gex/gex.lua
@@ -114,7 +114,7 @@ local function SendExtraStats()
             local utilValue = 0
             local ecoValue = 0
             local otherValue = 0
-            
+
             local metalCurrent, metalStorage, metalPull, metalIncome, metalExpense, metalShare, metalSent, metalReceived = Spring.GetTeamResources(teamID, "metal")
 			local energyCurrent, energyStorage, energyPull, energyIncome, energyExpense, energyShare, energySent, energyReceived = Spring.GetTeamResources(teamID, "energy")
 
@@ -155,6 +155,8 @@ local function SendExtraStats()
                 { "armyValue", armyValue },
                 { "defValue", defValue },
                 { "utilValue", utilValue },
+                { "metalCurrent", metalCurrent },
+                { "energyCurrent", energyCurrent },
                 { "ecoValue", ecoValue },
                 { "otherValue", otherValue },
 				{ "buildPowerAvailable", total_bp },

--- a/gex/gex.lua
+++ b/gex/gex.lua
@@ -9,10 +9,6 @@ local frame = 0
 local timer
 local commanders = {}
 
-local units_died_in_frame = {}
-local units_pending_load = {}
-local units_pending_unload = {}
-
 local CMD_RECLAIM = 90
 local CMD_RESTORE = 110
 local CMD_RESURRECT = 125
@@ -109,6 +105,9 @@ local function SendExtraStats()
 			local units = Spring.GetTeamUnits(teamID)
 			local total_metal_cost = 0
 
+            local metalCurrent, metalStorage, metalPull, metalIncome, metalExpense, metalShare, metalSent, metalReceived = Spring.GetTeamResources(teamID, "metal")
+			local energyCurrent, energyStorage, energyPull, energyIncome, energyExpense, energyShare, energySent, energyReceived = Spring.GetTeamResources(teamID, "energy")
+			
             local armyValue = 0
             local defValue = 0
             local utilValue = 0
@@ -154,6 +153,8 @@ local function SendExtraStats()
                 { "utilValue", utilValue },
                 { "ecoValue", ecoValue },
                 { "otherValue", otherValue },
+                { "metalCurrent", metalCurrent },
+                { "energyCurrent", energyCurrent },
 				{ "buildPowerAvailable", total_bp },
 				{ "buildPowerUsed", used_bp }
 			})
@@ -198,23 +199,6 @@ local function SendUnitPositions()
 end
 
 function widget:GameFrame(n)
-    -- 2025-06-22 HACK:
-    -- ok, this is really fucking stupid code, caused by the classic "what the fuck is a wupget"
-    -- widgets don't get the GameFramePost callin, but Gex still needs to emit this data at the
-    -- end of a frame, so Gex emits this data before the |frame| global is updated so the frame emitted
-    -- is one frame back from what the game's frame actually is :>
-    units_died_in_frame = {} -- reset back to nothing
-
-    for unitID,v in pairs(units_pending_load) do
-        writeJson("transport_loaded", v)
-    end
-    units_pending_load = {}
-
-    for unitID,v in pairs(units_pending_unload) do
-        writeJson("transport_unloaded", v)
-    end
-	units_pending_unload = {}
-
     frame = n
 
     local unitIDs = Spring.GetAllUnits()
@@ -249,15 +233,12 @@ function widget:GameFrame(n)
 
         for _,unitID in pairs(commanders) do
             local posx, posy, posz = Spring.GetUnitPosition(unitID)
-            -- sometimes this can be nil for reasons ??
-            if (posx ~= nil and posy ~= nil and posz ~= nil) then
-				writeJson("commander_position_update", {
-					{ "unitID", unitID },
-					{ "posX", posx, },
-					{ "posY", posy, },
-					{ "posZ", posz, }
-				})
-            end
+            writeJson("commander_position_update", {
+                { "unitID", unitID },
+                { "posX", posx, },
+                { "posY", posy, },
+                { "posZ", posz, }
+            })
         end
     end
 
@@ -299,7 +280,7 @@ function widget:GameOver(winningAllyTeams)
     for unitID,v in pairs(UNIT_RESOURCE_PRODUCTION) do
         -- HACK: for some reason, the UnitKilled callin setting nil does not work,
         -- and they are still iterated thru in this loop. but, GetUnitTeam will return nil for these units
-        if ((Spring.GetUnitTeam(unitID) ~= nil) and (units_died_in_frame[unitID] == nil)) then
+        if (Spring.GetUnitTeam(unitID) ~= nil) then
 			writeJson("unit_resources", {
 				{ "unitID", unitID },
                 { "defID", Spring.GetUnitDefID(unitID) },
@@ -314,7 +295,7 @@ function widget:GameOver(winningAllyTeams)
     end
 
     for unitID,v in pairs(UNIT_DAMAGE) do
-        if ((Spring.GetUnitTeam(unitID) ~= nil) and (units_died_in_frame[unitID] == nil)) then
+        if (Spring.GetUnitTeam(unitID) ~= nil) then
 			writeJson("unit_damage", {
 				{ "unitID", unitID },
 				{ "defID", Spring.GetUnitDefID(unitID) },
@@ -335,6 +316,7 @@ function widget:GameOver(winningAllyTeams)
             local history = Spring.GetTeamStatsHistory(teamID, 0, range)
 
             if (history) then
+
                 for i = 1,range do
                     data = {
                         { "teamID", teamID }
@@ -395,19 +377,6 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDef
         commanders[unitID] = nil
     end
 
-    units_died_in_frame[unitID] = unitID
-
-    -- if a unit was killed by crashing, assign the kill credit to whatever last hurt the unit
-    -- this is useful for air to air kills, as those mostly end with crashes
-    -- thanks to TheDujin for finding this bug and reporting it!
-    if (weaponDefID == -8) then
-        attackerID = Spring.GetUnitLastAttacker(unitID)
-        if (attackerID ~= nil) then
-            attackerDefID = Spring.GetUnitDefID(attackerID)
-            attackerTeam = Spring.GetUnitTeam(attackerID)
-        end
-    end
-
     local kx, ky, kz = Spring.GetUnitPosition(unitID)
     local ax, ay, az = nil, nil, nil
     if (attackerID ~= nil) then
@@ -459,35 +428,8 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attackerID, attackerDef
 end
 
 function widget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
-
-    -- 2025-06-21 HACK:
-    -- a unit can be loaded and unloaded by different transports multiple times per frame.
-    -- instead of sending all of those events, send all of the unit loaded events after the frame is over
-    -- ex:
-    -- {"action":"transport_loaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":10061,"transportTeamID":0,...}
-	-- {"action":"transport_unloaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":10061,"transportTeamID":0,...}
-	-- {"action":"transport_loaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":24424,"transportTeamID":0,...}
-	-- {"action":"transport_unloaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":24424,"transportTeamID":0,...}
-	-- {"action":"transport_loaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":29322,"transportTeamID":0,...}
-	-- {"action":"transport_unloaded","frame":47620,"unitID":25692,"defID":452,"teamID":0,"transportUnitID":29322,"transportTeamID":0,...}
-    --
-    -- note the unitID is the same for all events, but the transport ID is different
-    -- only emit the last one of these events per frame
-
     local x, y, z = Spring.GetUnitPosition(unitID)
 
-    units_pending_load[unitID] = {
-        { "unitID", unitID },
-        { "defID", unitDefID },
-        { "teamID", unitTeam },
-        { "transportUnitID", transportID },
-        { "transportTeamID", transportTeam },
-        { "unitX", x },
-        { "unitY", y },
-        { "unitZ", z }
-    }
-
-    --[[
     writeJson("transport_loaded", {
         { "unitID", unitID },
         { "defID", unitDefID },
@@ -498,25 +440,11 @@ function widget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTe
         { "unitY", y },
         { "unitZ", z }
     })
-    ]]
 end
 
 function widget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
-
     local x, y, z = Spring.GetUnitPosition(unitID)
 
-    units_pending_unload[unitID] = {
-        { "unitID", unitID },
-        { "defID", unitDefID },
-        { "teamID", unitTeam },
-        { "transportUnitID", transportID },
-        { "transportTeamID", transportTeam },
-        { "unitX", x },
-        { "unitY", y },
-        { "unitZ", z }
-    }
-
-    --[[
     writeJson("transport_unloaded", {
         { "unitID", unitID },
         { "defID", unitDefID },
@@ -527,7 +455,6 @@ function widget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transport
         { "unitY", y },
         { "unitZ", z }
     })
-    ]]
 end
 
 function widget:UnitFromFactory(unitID, unitDefID, unitTeam, factID, factDefID, userOrders)

--- a/gex/src/model/GameEventExtraStatsUpdate.ts
+++ b/gex/src/model/GameEventExtraStatsUpdate.ts
@@ -12,6 +12,8 @@ export class GameEventExtraStatsUpdate {
     public otherValue: number = 0;
     public buildPowerAvailable: number = 0;
     public buildPowerUsed: number = 0;
+    public metalCurrent: number = 0;
+    public energyCurrent: number = 0;
 
     public static parse(elem: any): GameEventExtraStatsUpdate {
         return {

--- a/gex/src/view/match/components/TeamStatsChart.vue
+++ b/gex/src/view/match/components/TeamStatsChart.vue
@@ -227,12 +227,14 @@
         ["buildPowerPercent", "Build power percent"],
 
         ["metalProduced", "Metal produced"],
+        ["metalCurrent", "Metal Current"],
         ["metalExcess", "Metal excess"],
         ["metalReceived", "Metal receieved"],
         ["metalSent", "Metal sent"],
         //["metalUsed", "Metal used"],
 
         ["energyProduced", "Energy produced"],
+        ["energyCurrent", "Energy Current"],
         ["energyExcess", "Energy excess"],
         ["energyReceived", "Energy receieved"],
         ["energySent", "Energy sent"],
@@ -289,11 +291,13 @@
                 ["metalProduced", "Metal produced"],
                 ["metalExcess", "Metal excess"],
                 ["metalReceived", "Metal receieved"],
+                ["metalCurrent", "Metal Current"],
                 ["metalSent", "Metal sent"],
                 ["energyProduced", "Energy produced"],
                 ["energyExcess", "Energy excess"],
                 ["energyReceived", "Energy receieved"],
                 ["energySent", "Energy sent"],
+                ["energyCurrent", "Energy Current"],
             ]
         },
         {

--- a/gex/src/view/match/compute/MergedStats.ts
+++ b/gex/src/view/match/compute/MergedStats.ts
@@ -72,6 +72,8 @@ export default class MergedStats {
                 defenseValue: extra?.defenseValue ?? 0,
                 utilValue: extra?.utilValue ?? 0,
                 otherValue: extra?.otherValue ?? 0,
+                metalCurrent: extra?.metalCurrent ?? 0,
+                energyCurrent: extra?.energyCurrent ?? 0,
                 buildPowerAvailable: extra?.buildPowerAvailable ?? 0,
                 buildPowerUsed: extra?.buildPowerUsed ?? 0,
                 buildPowerPercent: (extra?.buildPowerUsed ?? 0) / Math.max(1, (extra?.buildPowerAvailable ?? 0)) * 100

--- a/gex/src/view/match/compute/PlayerOpenerData.ts
+++ b/gex/src/view/match/compute/PlayerOpenerData.ts
@@ -16,6 +16,7 @@ export class PlayerOpener {
     public playerName: string = "";
     public color: string = "";
     public buildings: OpenerEntry[] = [];
+    public playerFaction: string = "";
 
     public static compute(match: BarMatch, output: GameOutput): PlayerOpener[] {
 
@@ -38,7 +39,8 @@ export class PlayerOpener {
                 teamID: teamID,
                 buildings: [],
                 playerName: "",
-                color: ""
+                color: "",
+                playerFaction: ""
             };
 
             const def: GameEventUnitDef | undefined = output.unitDefinitions.get(ev.definitionID);
@@ -90,6 +92,7 @@ export class PlayerOpener {
             const p: BarMatchPlayer | undefined = match.players.find(iter => iter.teamID == teamID);
             opener.playerName = p?.username ?? `<missing team ${teamID}>`;
             opener.color = p?.hexColor ?? "#000000";
+            opener.playerFaction = p?.faction ?? `<unknown>`;
         });
 
         return Array.from(map.values());

--- a/gex/src/view/match/compute/PlayerOpenerData.ts
+++ b/gex/src/view/match/compute/PlayerOpenerData.ts
@@ -16,7 +16,6 @@ export class PlayerOpener {
     public playerName: string = "";
     public color: string = "";
     public buildings: OpenerEntry[] = [];
-    public playerFaction: string = "";
 
     public static compute(match: BarMatch, output: GameOutput): PlayerOpener[] {
 
@@ -39,8 +38,7 @@ export class PlayerOpener {
                 teamID: teamID,
                 buildings: [],
                 playerName: "",
-                color: "",
-                playerFaction: ""
+                color: ""
             };
 
             const def: GameEventUnitDef | undefined = output.unitDefinitions.get(ev.definitionID);
@@ -92,7 +90,6 @@ export class PlayerOpener {
             const p: BarMatchPlayer | undefined = match.players.find(iter => iter.teamID == teamID);
             opener.playerName = p?.username ?? `<missing team ${teamID}>`;
             opener.color = p?.hexColor ?? "#000000";
-            opener.playerFaction = p?.faction ?? `<unknown>`;
         });
 
         return Array.from(map.values());


### PR DESCRIPTION
During the 15 seconds timer added additional stat pulled from the game engine, each players current metal and current energy. Added to Db and displayed under the "eco" tab on the frontend. 

(Games processed before update will show 0/0 for all players)