### PR TITLE
users fetch: Added an api to query multiple users in a single request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .github/
 .vs/
 TestResults
+.vscode/

--- a/gex/Services/Db/UserStats/BarUserDb.cs
+++ b/gex/Services/Db/UserStats/BarUserDb.cs
@@ -101,36 +101,6 @@ namespace gex.Services.Db.UserStats {
             );
         }
 
-        /// <summary>
-        ///     Search for users by a list of names using LIKE pattern matching, and optionally previous names. Case-insensitive.
-        ///     Uses the ANY operator for efficient searching of multiple patterns.
-        /// </summary>
-        /// <param name="names">List of names to search for (each will be wrapped with % for LIKE matching)</param>
-        /// <param name="includePreviousNames">If true, previous names will be searched as well</param>
-        /// <param name="cancel">Cancellation token</param>
-        /// <returns>A list of <see cref="UserSearchResult"/>s</returns>
-        public async Task<List<UserSearchResult>> SearchByNames(List<string> names, bool includePreviousNames, CancellationToken cancel) {
-            if (names == null || names.Count == 0) {
-                return new List<UserSearchResult>();
-            }
-
-            using NpgsqlConnection conn = _DbHelper.Connection(Dbs.MAIN);
-            
-            // Convert names to LIKE patterns
-            string[] searchPatterns = names.Select(n => $"%{n.ToLower()}%").ToArray();
-            
-            return await conn.QueryListAsync<UserSearchResult>(
-                includePreviousNames == true
-                    ? @"SELECT distinct(u.id) ""user_id"", u.username, u.last_updated, p.user_name ""previous_name""
-                            FROM bar_user u LEFT JOIN bar_match_player p ON p.user_id = u.id
-                            WHERE lower(u.username) LIKE ANY(@SearchPatterns) OR lower(p.user_name) LIKE ANY(@SearchPatterns)"
-                    : @"SELECT id ""user_id"", username, last_updated, username ""previous_name"" 
-                        FROM bar_user 
-                        WHERE lower(username) LIKE ANY(@SearchPatterns)",
-                new { SearchPatterns = searchPatterns },
-                cancellationToken: cancel
-            );
-        }
 
         /// <summary>
         ///     Get users by username matches, and optionally previous names. Case-insensitive.

--- a/gex/Services/Db/UserStats/BarUserDb.cs
+++ b/gex/Services/Db/UserStats/BarUserDb.cs
@@ -103,8 +103,7 @@ namespace gex.Services.Db.UserStats {
 
 
         /// <summary>
-        ///     Get users by username matches, and optionally previous names. Case-insensitive.
-        ///     Uses equality matching instead of LIKE pattern matching.
+        ///     Get users by username matches, and optionally previous names. Case-sensitive.
         /// </summary>
         /// <param name="usernames">List of usernames to find</param>
         /// <param name="includePreviousNames">If true, previous names will be searched as well</param>
@@ -116,9 +115,6 @@ namespace gex.Services.Db.UserStats {
             }
 
             using NpgsqlConnection conn = _DbHelper.Connection(Dbs.MAIN);
-            
-            // Convert usernames to lowercase for case-insensitive matching
-            string[] lowercaseUsernames = usernames.Select(n => n.ToLower()).ToArray();
 
             return await conn.QueryListAsync<BarUser>(
                 includePreviousNames == true
@@ -127,8 +123,8 @@ namespace gex.Services.Db.UserStats {
                             WHERE lower(u.username) = ANY(@Usernames) OR lower(p.user_name) = ANY(@Usernames)"
                     : @"SELECT id, username, last_updated, country_code 
                         FROM bar_user 
-                        WHERE lower(username) = ANY(@Usernames)",
-                new { Usernames = lowercaseUsernames },
+                        WHERE username = ANY(@Usernames)",
+                new { Usernames = usernames },
                 cancellationToken: cancel
             );
         }

--- a/gex/Services/Repositories/BarUserRepository.cs
+++ b/gex/Services/Repositories/BarUserRepository.cs
@@ -1,10 +1,12 @@
-﻿using gex.Models.Db;
+﻿using gex.Models.Api;
+using gex.Models.Db;
 using gex.Models.UserStats;
 using gex.Services.Db.UserStats;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -81,6 +83,27 @@ namespace gex.Services.Repositories {
         /// <returns>a list of <see cref="UserSearchResult"/>s</returns>
         public Task<List<UserSearchResult>> SearchByName(string name, bool includePreviousNames, CancellationToken cancel) {
             return _UserDb.SearchByName(name, includePreviousNames, cancel);
+        }
+
+        /// <summary>
+        ///     get users by username matches, and optionally previous names. case-insensitive
+        /// </summary>
+        /// <param name="usernames">list of usernames to find</param>
+        /// <param name="includePreviousNames">will previous names be searched as well</param>
+        /// <param name="cancel">cancellation token</param>
+        /// <returns>a list of <see cref="ApiBarUser"/>s</returns>
+        public async Task<List<ApiBarUser>> GetByUsernames(List<string> usernames, bool includePreviousNames, CancellationToken cancel) {
+            List<BarUser> dbUsers = await _UserDb.GetByUsernames(usernames, includePreviousNames, cancel);
+            
+            // Convert BarUser to ApiBarUser
+            return dbUsers
+                .Select(u => new ApiBarUser {
+                    UserID = u.UserID,
+                    Username = u.Username,
+                    LastUpdated = u.LastUpdated,
+                    CountryCode = u.CountryCode
+                })
+                .ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
Added an API `search/batch` to the `UserApiController`  derieved mostly from the search api to request player data for multiple users in a request. Limited the number of users that can be requested by 50 